### PR TITLE
Disabling of dispatch code generation

### DIFF
--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -70,6 +70,7 @@ impl GenerateCode for Dispatch<'_> {
             // since both resulting compilations do not require dispatching.
             #[cfg(not(test))]
             #no_cross_calling_cfg
+            #[cfg(not(feature = "ink-disable-dispatch"))]
             const _: () = {
                 #entry_points
                 #dispatch_using_mode

--- a/crates/lang/codegen/src/generator/metadata.rs
+++ b/crates/lang/codegen/src/generator/metadata.rs
@@ -37,6 +37,7 @@ impl GenerateCode for Metadata<'_> {
         quote! {
             #[cfg(feature = "std")]
             #[cfg(not(feature = "ink-as-dependency"))]
+            #[cfg(not(feature = "ink-disable-dispatch"))]
             const _: () = {
                 #[no_mangle]
                 pub fn __ink_generate_metadata() -> ::ink_metadata::InkProject  {


### PR DESCRIPTION
It adds the ability to inject the code of one contract into another. We remove entry points + don't generate metadata for sub-contracts.